### PR TITLE
Fix terminal colors in NeoVim w/ termguicolors

### DIFF
--- a/colors/deep-space.vim
+++ b/colors/deep-space.vim
@@ -185,3 +185,22 @@ call s:HL('GitGutterChangeDelete',          s:orange,   '',         '')
 call s:HL('SignifySignAdd',                 s:green,    '',         '')
 call s:HL('SignifySignChange',              s:yellow,   '',         '')
 call s:HL('SignifySignDelete',              s:red,      '',         '')
+
+if has("nvim") && exists("&termguicolors") && &termguicolors
+    let g:terminal_color_0  = "#1b202a"
+    let g:terminal_color_8  = "#232936"
+    let g:terminal_color_1  = "#b15e7c"
+    let g:terminal_color_9  = "#b3785d"
+    let g:terminal_color_2  = "#709d6c"
+    let g:terminal_color_10 = "#709d6c"
+    let g:terminal_color_3  = "#b5a262"
+    let g:terminal_color_11 = "#d5b875"
+    let g:terminal_color_4  = "#608cc3"
+    let g:terminal_color_12 = "#608cc3"
+    let g:terminal_color_5  = "#8f72bf"
+    let g:terminal_color_13 = "#c47ebd"
+    let g:terminal_color_6  = "#56adb7"
+    let g:terminal_color_14 = "#51617d"
+    let g:terminal_color_7  = "#323c4d"
+    let g:terminal_color_15 = "#9aa7bd"
+endif


### PR DESCRIPTION
I've grabbed the colors at [deep-space.xresources](https://github.com/tyrannicaltoucan/vim-deep-space/blob/master/term/deep-space.xresources) to fix colors under terminal buffers, otherwise the colors will look ugly. `g:terminal_color_*` is a workaround provided by NeoVim only, to help fix this issue.