### PR TITLE
Add option to honor terminal transparency

### DIFF
--- a/colors/deep-space.vim
+++ b/colors/deep-space.vim
@@ -12,6 +12,7 @@ set background=dark
 let g:colors_name = 'deep-space'
 
 let g:deepspace_italics = get(g:, 'deepspace_italics', 0)
+let g:deepspace_transparent = get(g:, 'deepspace_transparent', 0)
 
 " Color Palette
 let s:gray1     = '#1b202a'
@@ -185,6 +186,10 @@ call s:HL('GitGutterChangeDelete',          s:orange,   '',         '')
 call s:HL('SignifySignAdd',                 s:green,    '',         '')
 call s:HL('SignifySignChange',              s:yellow,   '',         '')
 call s:HL('SignifySignDelete',              s:red,      '',         '')
+
+if g:deepspace_transparent
+  exec 'hi! Normal guibg=NONE ctermbg=NONE'
+endif
 
 if has("nvim") && exists("&termguicolors") && &termguicolors
     let g:terminal_color_0  = "#1b202a"


### PR DESCRIPTION
From what I can tell, this color scheme won't honor terminals that are using a transparent (or any other background, really) themselves, since it will write over it with its own background color.

Looking at [this issue](https://github.com/vim/vim/issues/981), it seems like the way to get this fixed is to patch the color scheme we are using Neovim.

This PR adds an option, `deepspace_transparent`, which causes the colorscheme to not apply a background for `Normal`. I believe both `ctermbg` and `guibg` are necessary, but I could be wrong.

Also, there may be better ways to do this, feel free to change the diff here. Also, maybe this is not something you want, feel free to reject this and I'll personally use my fork. Or, if deep space can support this already, let me know how!